### PR TITLE
fix: :bug: make building a little better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9181,7 +9181,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surfpool-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -9231,7 +9231,7 @@ dependencies = [
 
 [[package]]
 name = "surfpool-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -9301,7 +9301,7 @@ dependencies = [
 
 [[package]]
 name = "surfpool-gql"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "convert_case 0.8.0",
@@ -9319,7 +9319,7 @@ dependencies = [
 
 [[package]]
 name = "surfpool-subgraph"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "agave-geyser-plugin-interface",
  "ipc-channel",
@@ -9333,7 +9333,7 @@ dependencies = [
 
 [[package]]
 name = "surfpool-types"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Surfpool is the best place to train before surfing Solana."
 license = "Apache-2.0"
@@ -63,15 +63,7 @@ solana-transaction-context = { version = "2.2.1", features = ["serde"]}
 solana-transaction-error = { version = "2.2.1", features = ["serde"]}
 solana-transaction-status = { version = "2.2.2" }
 solana-version = "2.2.1"
-spl-associated-token-account =  "6.0.0"
-# txtx-addon-kit = { path = "../txtx/crates/txtx-addon-kit", features = ["wasm"]}
-# txtx-addon-network-svm = { package = "txtx-addon-network-svm", path = "../txtx/addons/svm/core" }
-# txtx-addon-network-svm-types = { package = "txtx-addon-network-svm-types", path = "../txtx/addons/svm/types" }
-# txtx-core = { path = "../txtx/crates/txtx-core" }
-# txtx-gql = { path = "../txtx/crates/txtx-gql" }
-# txtx-cloud = { path = "../txtx/crates/txtx-cloud" }
-# txtx-supervisor-ui = { path = "../txtx/crates/txtx-supervisor-ui", default-features = false, features = ["bin_build"] }
-# txtx-cloud = { path = "../txtx/crates/txtx-cloud" }
+spl-associated-token-account = "6.0.0"
 txtx-addon-kit = { version = "0.2.11", features = ["wasm"] }
 txtx-core = { version = "0.2.14" }
 txtx-addon-network-svm = { version = "0.1.18" }
@@ -80,3 +72,12 @@ txtx-gql = { version = "0.2.6" }
 txtx-supervisor-ui = { version = "0.1.4", default-features = false, features = ["crates_build"]}
 txtx-cloud = "0.1.3"
 uuid = "1.15.1"
+
+# [patch.crates-io]
+# txtx-addon-kit = { path = "../txtx/crates/txtx-addon-kit" }
+# txtx-core = { path = "../txtx/crates/txtx-core" }
+# txtx-addon-network-svm = { path = "../txtx/addons/svm/core" }
+# txtx-addon-network-svm-types = { path = "../txtx/addons/svm/types" }
+# txtx-gql = { path = "../txtx/crates/txtx-gql" }
+# txtx-supervisor-ui = { path = "../txtx/crates/txtx-supervisor-ui" }
+# txtx-cloud = { path = "../txtx/crates/txtx-cloud" }

--- a/crates/cli/src/runbook/mod.rs
+++ b/crates/cli/src/runbook/mod.rs
@@ -245,7 +245,10 @@ pub async fn configure_supervised_execution(
     let (block_broadcaster, _) = tokio::sync::broadcast::channel(5);
     let block_store = Arc::new(RwLock::new(BTreeMap::new()));
     let (kill_loops_tx, kill_loops_rx) = channel::bounded(1);
+    #[cfg(feature = "supervisor_ui")]
     let (action_item_events_tx, action_item_events_rx) = tokio::sync::broadcast::channel(32);
+    #[cfg(not(feature = "supervisor_ui"))]
+    let (_, action_item_events_rx) = tokio::sync::broadcast::channel(32);
 
     let moved_block_tx = block_tx.clone();
     let moved_kill_loops_tx = kill_loops_tx.clone();


### PR DESCRIPTION
# Bump version to 0.2.3

### TL;DR
Bumps the version from 0.2.2 to 0.2.3 across all crates and adds conditional compilation for action item events.

### What changed?
- Updated version from 0.2.2 to 0.2.3 in Cargo.toml and Cargo.lock for all surfpool packages
- Cleaned up commented-out dependencies in Cargo.toml
- Added patch section (commented out) for local development
- Added conditional compilation for action_item_events_tx based on the "supervisor_ui" feature flag

### How to test?
- Verify that the version is correctly updated in all packages
- Build with and without the "supervisor_ui" feature to ensure conditional compilation works correctly

### Why make this change?
This change prepares for a new release version and improves the codebase by removing unused commented code. The conditional compilation ensures that action_item_events_tx is only created when the supervisor UI feature is enabled, avoiding unused variable warnings.